### PR TITLE
refactor: implemented runAsync hook in Create/EditProfileFormWrapper

### DIFF
--- a/src/components/CreateProfileForm/CreateProfileFormWrapper.tsx
+++ b/src/components/CreateProfileForm/CreateProfileFormWrapper.tsx
@@ -1,11 +1,12 @@
 'use client'
-import React, { PropsWithChildren } from 'react'
-import { Formik } from 'formik'
-import * as Yup from 'yup'
 import { CreateProfilePayload } from '@/data/frontend/profile/types'
+import { useAsyncAction } from '@/hooks/useAsyncAction'
 import { apiClient } from '@/lib/apiClient'
-import { useSession } from 'next-auth/react'
 import { EmploymentType, PublishingState } from '@prisma/client'
+import { Formik } from 'formik'
+import { useSession } from 'next-auth/react'
+import { PropsWithChildren } from 'react'
+import * as Yup from 'yup'
 
 export interface CreateProfileFormValues {
   fullName: string
@@ -64,7 +65,7 @@ export const validationSchema = Yup.object().shape({
 
 const CreateProfileFormWrapper = ({ children }: PropsWithChildren) => {
   const { data: session } = useSession()
-
+  const { runAsync } = useAsyncAction()
   if (!session) {
     return null
   }
@@ -92,12 +93,9 @@ const CreateProfileFormWrapper = ({ children }: PropsWithChildren) => {
       githubUsername: null,
       state: PublishingState.DRAFT,
     }
-
-    try {
-      const createdProfile = await apiClient.createMyProfile(payload)
-    } catch (error) {
-      console.log(error)
-    }
+    await runAsync(async () => {
+      await apiClient.createMyProfile(payload)
+    })
   }
 
   return (

--- a/src/components/EditProfileForm/EditProfileFormWrapper.tsx
+++ b/src/components/EditProfileForm/EditProfileFormWrapper.tsx
@@ -1,12 +1,13 @@
 'use client'
-import React, { PropsWithChildren } from 'react'
-import { Formik } from 'formik'
-import * as Yup from 'yup'
-import { EditProfilePayload, ProfileModel } from '@/data/frontend/profile/types'
-import { apiClient } from '@/lib/apiClient'
-import { useSession } from 'next-auth/react'
-import { EmploymentType, PublishingState } from '@prisma/client'
 import { mapProfileModelToEditProfileFormValues } from '@/components/EditProfileForm/mappers'
+import { EditProfilePayload, ProfileModel } from '@/data/frontend/profile/types'
+import { useAsyncAction } from '@/hooks/useAsyncAction'
+import { apiClient } from '@/lib/apiClient'
+import { EmploymentType, PublishingState } from '@prisma/client'
+import { Formik } from 'formik'
+import { useSession } from 'next-auth/react'
+import { PropsWithChildren } from 'react'
+import * as Yup from 'yup'
 
 export interface EditProfileFormValues {
   fullName: string
@@ -70,6 +71,7 @@ const EditProfileFormWrapper = ({
   profile,
 }: PropsWithChildren<EditProfileFormWrapperProps>) => {
   const { data: session } = useSession()
+  const { runAsync } = useAsyncAction()
 
   if (!session) {
     return null
@@ -98,7 +100,9 @@ const EditProfileFormWrapper = ({
       githubUsername: null,
       state: PublishingState.PENDING,
     }
-    await apiClient.updateMyProfile(payload)
+    await runAsync(async () => {
+      await apiClient.updateMyProfile(payload)
+    })
   }
 
   const mappedInitialValues: EditProfileFormValues =


### PR DESCRIPTION
# Summary: 
To be honest this task has been done in the meantime as i can see, yet i've found 2 functions that would benefit from runAsync hook in Create/EditProfileFormWrapper. 

# Notes: 
- Task mentioned only POST requests, yet i've also edited one PUT request.
- Seen some getRequests on the way, if needed I can wrap them too. 