### PR TITLE
fix: assign role button and modal are now resembling user roles

### DIFF
--- a/app/(moderation)/dashboard/profile/[id]/page.tsx
+++ b/app/(moderation)/dashboard/profile/[id]/page.tsx
@@ -1,13 +1,14 @@
+import { getProfileByUserId } from '@/backend/profile/profile.service'
+import ModerationActionHeader from '@/components/Headers/ModerationActionHeader/ModerationActionHeader'
 import UserProfileHeader from '@/components/Headers/UserProfileHeader/UserProfileHeader'
 import UserProfileDetails from '@/components/UserProfile/UserProfileDetails/UserProfileDetails'
 import UserProfileMain from '@/components/UserProfile/UserProfileMain/UserProfileMain'
-import ModerationActionHeader from '@/components/Headers/ModerationActionHeader/ModerationActionHeader'
-import { AppRoutes } from '@/utils/routes'
-import { redirect } from 'next/navigation'
-import { Role } from '@prisma/client'
 import { requireUserRoles } from '@/utils/auths'
-import { getProfileByUserId } from '@/backend/profile/profile.service'
+import { AppRoutes } from '@/utils/routes'
+import { Role } from '@prisma/client'
+import { redirect } from 'next/navigation'
 
+import { findUserByEmail } from '@/backend/user/user.service'
 import styles from './page.module.scss'
 
 export default async function ModerationUserProfile({
@@ -16,12 +17,14 @@ export default async function ModerationUserProfile({
   params: { id: string }
 }) {
   const profile = await getProfileByUserId(params.id)
+  const user = profile && (await findUserByEmail(profile.userEmail))
 
-  if (!profile || !requireUserRoles([Role.MODERATOR])) redirect(AppRoutes.home)
+  if (!profile || !user || !requireUserRoles([Role.MODERATOR]))
+    redirect(AppRoutes.home)
 
   return (
     <div className={styles.wrapper}>
-      <ModerationActionHeader userProfile={profile} />
+      <ModerationActionHeader userProfile={profile} userRoles={user.roles} />
       <UserProfileMain userProfile={profile}>
         <UserProfileHeader userProfile={profile} />
       </UserProfileMain>

--- a/src/components/AssignRoleModal/AssignRoleModal.tsx
+++ b/src/components/AssignRoleModal/AssignRoleModal.tsx
@@ -1,16 +1,19 @@
 import { Button } from '@/components/Button/Button'
 
-import styles from './AssignRole.module.scss'
 import modalStyles from '@/components/Modal/Modal.module.scss'
+import { Role } from '@prisma/client'
+import styles from './AssignRole.module.scss'
 
 export default function AssignRoleModal({
   profileId,
+  userRoles,
   onClose,
 }: {
   profileId: string
+  userRoles: Role[]
   onClose: () => void
 }) {
-  return (
+  return !userRoles.includes(Role.MODERATOR) ? (
     <div className={modalStyles.container}>
       <h4>Assign admin role</h4>
       <p className={styles.info}>
@@ -22,6 +25,21 @@ export default function AssignRoleModal({
         <Button variant="primary">Yes, assign</Button>
         <Button variant={'action'} onClick={() => onClose()}>
           No, don't assign
+        </Button>
+      </div>
+    </div>
+  ) : (
+    <div className={modalStyles.container}>
+      <h4>Unassign admin role</h4>
+      <p className={styles.info}>
+        User will no more have full moderation permissions and option to assign
+        other profiles as admins. <br />
+        Are you sure you want to unassign this role?
+      </p>
+      <div className={modalStyles.actionButtons}>
+        <Button variant="primary">Yes, unassign</Button>
+        <Button variant={'action'} onClick={() => onClose()}>
+          No, don't unassign
         </Button>
       </div>
     </div>

--- a/src/components/Headers/ModerationActionHeader/ModerationActionHeader.tsx
+++ b/src/components/Headers/ModerationActionHeader/ModerationActionHeader.tsx
@@ -1,16 +1,18 @@
 'use client'
+import { Button } from '@/components/Button/Button'
 import GoBackButton from '@/components/GoBackButton/GoBackButton'
 import { StateStatus } from '@/components/ProfileList/ModerationProfileListItem'
-import { Button } from '@/components/Button/Button'
-import { UserProfileHeaderType } from '../types'
 import { useModal } from '@/contexts/ModalContext'
 
-import styles from './ModerationActionHeader.module.scss'
 import AssignRoleModal from '@/components/AssignRoleModal/AssignRoleModal'
+import { Role } from '@prisma/client'
+import { ModerationActionHeaderType } from '../types'
+import styles from './ModerationActionHeader.module.scss'
 
 export default function ModerationActionHeader({
   userProfile,
-}: UserProfileHeaderType) {
+  userRoles,
+}: ModerationActionHeaderType) {
   const { showModal, closeModal } = useModal()
 
   return (
@@ -23,12 +25,15 @@ export default function ModerationActionHeader({
             showModal(
               <AssignRoleModal
                 profileId={userProfile.id}
+                userRoles={userRoles}
                 onClose={closeModal}
               />,
             )
           }}
         >
-          Assign admin role
+          {userRoles.includes(Role.MODERATOR)
+            ? 'Unassign admin role'
+            : 'Assign admin role'}
         </Button>
         <div className={styles.vl}></div>
         <StateStatus profile={userProfile} />

--- a/src/components/Headers/types.ts
+++ b/src/components/Headers/types.ts
@@ -1,6 +1,11 @@
 import { ProfileModel } from '@/data/frontend/profile/types'
+import { Role } from '@prisma/client'
 
 export type UserProfileHeaderType = {
   userProfile: ProfileModel
   withBackButton?: boolean
+}
+
+export type ModerationActionHeaderType = UserProfileHeaderType & {
+  userRoles: Role[]
 }


### PR DESCRIPTION
# Summary: 
- assign role button and modal are now properly displaying information depending on selected user roles.

# Notes: 
- backend logic as i can see is not implemented yet, task idea: implement this feature (as far as i know it should be possible to do so right now)