### PR TITLE
Feat/spam prevention

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "18.2.0",
         "react-icons": "^4.9.0",
         "react-select": "^5.7.3",
+        "request-ip": "^3.3.0",
         "sass": "^1.63.4",
         "yup": "^1.2.0"
       },
@@ -34,6 +35,7 @@
         "@types/node": "20.2.5",
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.4",
+        "@types/request-ip": "^0.0.41",
         "@typescript-eslint/eslint-plugin": "^5.59.7",
         "classnames": "^2.3.2",
         "cypress": "^13.6.0",
@@ -1388,6 +1390,15 @@
       "integrity": "sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/request-ip": {
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@types/request-ip/-/request-ip-0.0.41.tgz",
+      "integrity": "sha512-Qzz0PM2nSZej4lsLzzNfADIORZhhxO7PED0fXpg4FjXiHuJ/lMyUg+YFF5q8x9HPZH3Gl6N+NOM8QZjItNgGKg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/scheduler": {
@@ -8022,6 +8033,11 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/request-ip": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
+      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA=="
+    },
     "node_modules/request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -10388,6 +10404,15 @@
       "integrity": "sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/request-ip": {
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@types/request-ip/-/request-ip-0.0.41.tgz",
+      "integrity": "sha512-Qzz0PM2nSZej4lsLzzNfADIORZhhxO7PED0fXpg4FjXiHuJ/lMyUg+YFF5q8x9HPZH3Gl6N+NOM8QZjItNgGKg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/scheduler": {
@@ -14787,6 +14812,11 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
+    },
+    "request-ip": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
+      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA=="
     },
     "request-progress": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-dom": "18.2.0",
     "react-icons": "^4.9.0",
     "react-select": "^5.7.3",
+    "request-ip": "^3.3.0",
     "sass": "^1.63.4",
     "yup": "^1.2.0"
   },
@@ -52,6 +53,7 @@
     "@types/node": "20.2.5",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.4",
+    "@types/request-ip": "^0.0.41",
     "@typescript-eslint/eslint-plugin": "^5.59.7",
     "classnames": "^2.3.2",
     "cypress": "^13.6.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,6 +87,14 @@ model ContactRequest {
   profile        Profile @relation(fields: [profileId], references: [id])
   profileId      String
 }
+// TODO: figure out a way to delete profileId if profile/user is deleted.
+// used to prevent spamming contact requests to profiles
+model IpTrack {
+  id          String    @id @default(uuid())
+  ip          String    @unique// Store the IP address
+  profileIds  String[]  // Associated profile ids
+  createdAt   DateTime  @default(now())
+}
 
 enum EmploymentType {
   FULL_TIME

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,31 +23,32 @@ model User {
 }
 
 model Profile {
-  id                        String            @id @default(uuid())
-  user                      User              @relation(fields: [userId], references: [id])
-  userId                    String            @unique
-  fullName                  String
-  linkedIn                  String?
-  bio                       String
-  country                   Country           @relation(fields: [countryId], references: [id])
-  countryId                 String
-  openForCountryRelocation  Boolean           @default(false)
-  city                      City              @relation(fields: [cityId], references: [id])
-  cityId                    String
-  openForCityRelocation     Boolean           @default(false)
-  remoteOnly                Boolean
-  position                  String           
-  seniority                 String
-  techStack                 Technology[]
-  employmentTypes           EmploymentType[]
-  state                     PublishingState   @default(DRAFT)
-  rejectionReasons          RejectionReason[]
+  id                       String            @id @default(uuid())
+  user                     User              @relation(fields: [userId], references: [id])
+  userId                   String            @unique
+  fullName                 String
+  linkedIn                 String?
+  bio                      String
+  country                  Country           @relation(fields: [countryId], references: [id])
+  countryId                String
+  openForCountryRelocation Boolean           @default(false)
+  city                     City              @relation(fields: [cityId], references: [id])
+  cityId                   String
+  openForCityRelocation    Boolean           @default(false)
+  remoteOnly               Boolean
+  position                 String
+  seniority                String
+  techStack                Technology[]
+  employmentTypes          EmploymentType[]
+  state                    PublishingState   @default(DRAFT)
+  rejectionReasons         RejectionReason[]
+  contactRequests          ContactRequest[]
 }
 
 model Technology {
-  id          String                 @id @default(uuid())
-  name        String                 @unique
-  profiles    Profile[]
+  id       String    @id @default(uuid())
+  name     String    @unique
+  profiles Profile[]
 }
 
 model GitHubDetails {
@@ -75,6 +76,16 @@ model RejectionReason {
   profileId String
   reason    String
   createdAt DateTime @default(now())
+}
+
+model ContactRequest {
+  id             String  @id @default(uuid())
+  subject        String
+  message        String
+  senderFullName String
+  senderEmail    String
+  profile        Profile @relation(fields: [profileId], references: [id])
+  profileId      String
 }
 
 enum EmploymentType {

--- a/src/app/api/contactRequest/route.ts
+++ b/src/app/api/contactRequest/route.ts
@@ -1,0 +1,18 @@
+import { saveContactRequest } from '@/backend/contactRequest/contactRequest.service'
+import { ContactFormRequest } from '@/components/ContactForm/schema'
+import { NextRequest, NextResponse } from 'next/server'
+export async function POST(request: NextRequest) {
+  try {
+    const contactFormRequest: ContactFormRequest = await request.json()
+
+    const createdContactRequest = await saveContactRequest(contactFormRequest)
+
+    return NextResponse.json({
+      status: 201,
+      contactRequest: createdContactRequest,
+    })
+  } catch (error) {
+    console.log('Error:', error)
+    return new NextResponse(`${error}`, { status: 500 })
+  }
+}

--- a/src/app/api/contactRequest/route.ts
+++ b/src/app/api/contactRequest/route.ts
@@ -1,12 +1,94 @@
+// import { saveContactRequest } from '@/backend/contactRequest/contactRequest.service'
+// import {
+//   createIpTrack,
+//   findIpTrack,
+//   updateIpTrack,
+// } from '@/backend/ipTrack/ipTrack.service'
+// import { ContactFormRequest } from '@/components/ContactForm/schema'
+// import { NextApiRequest } from 'next'
+// import { NextResponse } from 'next/server'
+// import requestIp from 'request-ip'
 import { saveContactRequest } from '@/backend/contactRequest/contactRequest.service'
+import {
+  createIpTrack,
+  findIpTrack,
+  updateIpTrack,
+} from '@/backend/ipTrack/ipTrack.service'
 import { ContactFormRequest } from '@/components/ContactForm/schema'
 import { NextRequest, NextResponse } from 'next/server'
+
+// export async function POST(request: NextApiRequest) {
+//   try {
+//     const contactFormRequest: ContactFormRequest = await request.body
+
+//     const detectedIp = requestIp.getClientIp(request)
+//     if (!detectedIp) {
+//       return NextResponse.json({
+//         status: 403,
+//         message: `Spam prevention, ip is undefined, headers: ${JSON.stringify(
+//           request.headers,
+//         )}`,
+//       })
+//     }
+//     const ipTrack = await findIpTrack(detectedIp)
+//     if (ipTrack) {
+//       if (ipTrack.profileIds.includes(contactFormRequest.profileId)) {
+//         return NextResponse.json({
+//           status: 403,
+//           message:
+//             "Spam prevention, you've sent already message to this profile",
+//         })
+//       } else {
+//         updateIpTrack(ipTrack.ip, [
+//           ...ipTrack.profileIds,
+//           contactFormRequest.profileId,
+//         ])
+//       }
+//     } else {
+//       createIpTrack(detectedIp, [contactFormRequest.profileId])
+//     }
+//     const createdContactRequest = await saveContactRequest(contactFormRequest)
+//     return NextResponse.json({
+//       status: 201,
+//       contactRequest: createdContactRequest,
+//     })
+//   } catch (error) {
+//     console.log('Error:', error)
+//     return new NextResponse(`${error}`, { status: 500 })
+//   }
+// }
+
 export async function POST(request: NextRequest) {
   try {
     const contactFormRequest: ContactFormRequest = await request.json()
 
+    const detectedIp = request.ip
+    if (!detectedIp) {
+      return NextResponse.json({
+        status: 403,
+        message: `Spam prevention, ip is undefined, headers: ${JSON.stringify(
+          request.headers,
+        )}`,
+      })
+    }
+    const ipTrack = await findIpTrack(detectedIp)
+    if (ipTrack) {
+      if (ipTrack.profileIds.includes(contactFormRequest.profileId)) {
+        return NextResponse.json({
+          status: 403,
+          message:
+            "Spam prevention, you've sent already message to this profile",
+        })
+      } else {
+        updateIpTrack(ipTrack.ip, [
+          ...ipTrack.profileIds,
+          contactFormRequest.profileId,
+        ])
+      }
+    } else {
+      createIpTrack(detectedIp, [contactFormRequest.profileId])
+    }
     const createdContactRequest = await saveContactRequest(contactFormRequest)
-
     return NextResponse.json({
       status: 201,
       contactRequest: createdContactRequest,

--- a/src/backend/contactRequest/contactRequest.service.ts
+++ b/src/backend/contactRequest/contactRequest.service.ts
@@ -1,0 +1,13 @@
+import { ContactFormRequest } from '@/components/ContactForm/schema'
+import { prisma } from '@/lib/prismaClient'
+export async function saveContactRequest(contactRequest: ContactFormRequest) {
+  return prisma.contactRequest.create({
+    data: {
+      subject: contactRequest.subject,
+      message: contactRequest.message,
+      senderFullName: contactRequest.senderFullName,
+      senderEmail: contactRequest.senderEmail,
+      profileId: contactRequest.profileId,
+    },
+  })
+}

--- a/src/backend/contactRequest/contactRequest.service.ts
+++ b/src/backend/contactRequest/contactRequest.service.ts
@@ -1,5 +1,6 @@
 import { ContactFormRequest } from '@/components/ContactForm/schema'
 import { prisma } from '@/lib/prismaClient'
+
 export async function saveContactRequest(contactRequest: ContactFormRequest) {
   return prisma.contactRequest.create({
     data: {

--- a/src/backend/ipTrack/ipTrack.service.ts
+++ b/src/backend/ipTrack/ipTrack.service.ts
@@ -1,0 +1,42 @@
+import { prisma } from '@/lib/prismaClient'
+
+export async function findIpTrack(ip: string) {
+  return prisma.ipTrack.findUnique({
+    where: {
+      ip,
+    },
+  })
+}
+
+// export async function upsertIpTrack(ip: string, profileIds: string[]) {
+//   return prisma.ipTrack.upsert({
+//     create: {
+//       ip,
+//       profileIds,
+//     },
+//     update: {
+//       profileIds,
+//     },
+//     where: { ip: ip },
+//   })
+// }
+
+export async function createIpTrack(ip: string, profileIds: string[]) {
+  return prisma.ipTrack.create({
+    data: {
+      ip,
+      profileIds,
+    },
+  })
+}
+
+export async function updateIpTrack(ip: string, profileIds: string[]) {
+  return prisma.ipTrack.update({
+    data: {
+      profileIds,
+    },
+    where: {
+      ip,
+    },
+  })
+}

--- a/src/components/ContactForm/ContactForm.tsx
+++ b/src/components/ContactForm/ContactForm.tsx
@@ -24,10 +24,12 @@ export default function ContactForm({
     runAsync(async () => {
       try {
         // Handle submit actions
-        apiClient.saveContactRequest({
-          ...values,
-          profileId: userProfile.id,
-        }),
+        console.log(
+          apiClient.saveContactRequest({
+            ...values,
+            profileId: userProfile.id,
+          }),
+        ),
           // console.log('Handle submit', values)
           showSuccessMsg()
         window.scrollTo({ top: 0, behavior: 'smooth' })

--- a/src/components/ContactForm/ContactForm.tsx
+++ b/src/components/ContactForm/ContactForm.tsx
@@ -4,6 +4,7 @@ import TextArea from '@/components/TextArea/TextArea'
 import TextInput from '@/components/TextInput/TextInput'
 import { ProfileModel } from '@/data/frontend/profile/types'
 import { useAsyncAction } from '@/hooks/useAsyncAction'
+import { apiClient } from '@/lib/apiClient'
 import { useFormik } from 'formik'
 import styles from './ContactForm.module.scss'
 import { ContactFormValues, initialValues, validationSchema } from './schema'
@@ -23,8 +24,12 @@ export default function ContactForm({
     runAsync(async () => {
       try {
         // Handle submit actions
-        // console.log('Handle submit', values)
-        showSuccessMsg()
+        apiClient.saveContactRequest({
+          ...values,
+          profileId: userProfile.id,
+        }),
+          // console.log('Handle submit', values)
+          showSuccessMsg()
         window.scrollTo({ top: 0, behavior: 'smooth' })
       } catch (error) {
         console.error('Error sending email', error)

--- a/src/components/ContactForm/schema.ts
+++ b/src/components/ContactForm/schema.ts
@@ -7,6 +7,10 @@ export interface ContactFormValues {
   message: string
 }
 
+export interface ContactFormRequest extends ContactFormValues {
+  profileId: string
+}
+
 export const initialValues: ContactFormValues = {
   senderFullName: '',
   senderEmail: '',

--- a/src/components/Dropdowns/DropdownFilterMulti/DropdownFilterMulti.tsx
+++ b/src/components/Dropdowns/DropdownFilterMulti/DropdownFilterMulti.tsx
@@ -60,7 +60,6 @@ export const DropdownFilterMulti = ({
   }
 
   const [isOverlayActive, setOverlayActive] = useState(false)
-  console.log(options)
   return (
     <div className={styles.buttonBox}>
       <div ref={dropdownRef}>

--- a/src/components/UserProfile/UserProfileMain/UserProfileMain.tsx
+++ b/src/components/UserProfile/UserProfileMain/UserProfileMain.tsx
@@ -1,5 +1,8 @@
 import { countries } from '@/data/frontend/profile/countries/countries'
-import { mapEmploymentTypes } from '@/data/frontend/profile/mappers'
+import {
+  mapEmploymentTypes,
+  mapSeniorityLevel,
+} from '@/data/frontend/profile/mappers'
 import { ProfileModel } from '@/data/frontend/profile/types'
 import Image from 'next/image'
 import { PropsWithChildren } from 'react'
@@ -46,7 +49,8 @@ const UserProfileMain = ({
         </div>
         <div className={styles.addInfoBox}>
           <div className={styles.seniority}>
-            {userProfile.seniority} {userProfile.position} Developer
+            {mapSeniorityLevel(userProfile.seniority)} {userProfile.position}{' '}
+            Developer
           </div>
           <div className={styles.addInfo}>
             <div className={styles.addInfoItem}>

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { ContactFormRequest } from '@/components/ContactForm/schema'
 import {
   CreateProfilePayload,
   ProfileModel,
@@ -6,7 +7,7 @@ import {
   RejectionReason,
 } from '@/data/frontend/profile/types'
 import { httpClient } from '@/lib/httpClient'
-import { Profile } from '@prisma/client'
+import { ContactRequest, Profile } from '@prisma/client'
 import { PutBlobResult } from '@vercel/blob'
 
 export const apiClient = {
@@ -79,6 +80,18 @@ export const apiClient = {
       return url
     } catch (error) {
       throw new Error(error as string)
+    }
+  },
+  saveContactRequest: async (contactRequest: ContactFormRequest) => {
+    try {
+      const savedContactRequest = await httpClient.post<
+        ContactFormRequest,
+        ContactRequest
+      >('/api/contactRequest', contactRequest)
+
+      return savedContactRequest
+    } catch (error) {
+      console.log(error)
     }
   },
 }


### PR DESCRIPTION
# Summary:
- implemented spam prevention feature with Ip tracking - one ip shouldn't be able to send 2 messages to one profile, there's also createdAt field so it would be easier to implement deleting such track after some time.
- there's a question about realtionship to profile, should it be implemented? It would be easier to manage IpTrack profileID's list (e.g. profile is deleted, hence ipTrack profileID is deleted aswell)
- didn't test it yet properly (on localhost request headers aren't existent as far as i can see), cuz it's
 --A: working on not integrated yet branch with related feature (save contact request) 
 --B: save contact request +  DB changes, didn't want to push them to remote base.

# Could be useful:
https://stackoverflow.com/questions/68338838/how-to-get-the-ip-address-of-the-client-from-server-side-in-next-js-app (TL;DR request-ip mentioned and NextRequest mentioned)
https://github.com/vercel/next.js/discussions/34609 (TL;DR comment in this thread says: it should work on remote host)

# Notes:
- there are 2 ways of collecting ip, one requires package and is using other interface in request, second one is fully compatible with our current codebase (not sure which one is better, cuz couldn't measure it's performance -> can't get ip so...)