### PR TITLE
fix: discord notification

### DIFF
--- a/src/app/(auth)/_actions/mutations/registerNewUser.ts
+++ b/src/app/(auth)/_actions/mutations/registerNewUser.ts
@@ -31,7 +31,7 @@ export const registerNewUser = withSentry(
     await sendDiscordNotificationToModeratorChannel(
       `User ${devName} has created an account as ${
         githubUsername
-          ? `SPECIALIST ${!name && `with ${createdUser.email}`}`
+          ? `SPECIALIST ${!name ? `with ${createdUser.email}` : ''}`
           : 'HUNTER'
       }`,
     )


### PR DESCRIPTION
Invalid syntax led to the addition of 'false' at the end of the notification when a specialist created an account and their GitHub profile contained a name

before:
![image](https://github.com/nerdbord/good-dev-hunting-app/assets/110562040/0633be8e-fa5d-4d5f-93a0-dd6a4fc6a40c)


after:
![image](https://github.com/nerdbord/good-dev-hunting-app/assets/110562040/69da0755-cb80-4342-90c9-e0333b96d792)
