### PR TITLE
anchor button now ensures https

### DIFF
--- a/packages/ui-system/src/components/Button/AnchorButton.tsx
+++ b/packages/ui-system/src/components/Button/AnchorButton.tsx
@@ -2,19 +2,13 @@ import { type PropsWithChildren } from "react";
 
 import Link from "next/link";
 import styles from "./AnchorButton.module.scss";
+import { ensureProtocol } from "@/utils/routes";
 
 interface AnchorButton {
   href: string;
   icon?: React.ReactElement;
 }
 
-const ensureProtocol = (url: string) => {
-  // Check if the URL starts with "http://" or "https://"
-  if (/^(https?:\/\/)/i.test(url)) {
-    return url; // Return the URL as it is if it has a protocol
-  }
-  return `https://${url}`; // Prepend https:// if no protocol is present
-};
 
 export const AnchorButton = (props: PropsWithChildren<AnchorButton>) => {
   return (

--- a/packages/ui-system/src/components/Button/AnchorButton.tsx
+++ b/packages/ui-system/src/components/Button/AnchorButton.tsx
@@ -8,11 +8,19 @@ interface AnchorButton {
   icon?: React.ReactElement;
 }
 
+const ensureProtocol = (url: string) => {
+  // Check if the URL starts with "http://" or "https://"
+  if (/^(https?:\/\/)/i.test(url)) {
+    return url; // Return the URL as it is if it has a protocol
+  }
+  return `https://${url}`; // Prepend https:// if no protocol is present
+};
+
 export const AnchorButton = (props: PropsWithChildren<AnchorButton>) => {
   return (
     <Link
       className={styles.socialItem}
-      href={props.href}
+      href={ensureProtocol(props.href)}
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/packages/ui-system/src/utils/routes.ts
+++ b/packages/ui-system/src/utils/routes.ts
@@ -11,3 +11,11 @@ export enum AppRoutes {
   signIn = "/signin",
   error = "/error",
 }
+
+export const ensureProtocol = (url: string) => {
+  // Check if the URL starts with "http://" or "https://"
+  if (/^(https?:\/\/)/i.test(url)) {
+    return url; // Return the URL as it is if it has a protocol
+  }
+  return `https://${url}`; // Prepend https:// if no protocol is present
+};


### PR DESCRIPTION
In next.js Link element, any url not starting with the https:// protocol is being treated as an internal link. This change fixes the problem by making sure the url provided to the nextjs link element is always prepended with the protocol.