### PR TITLE
feat: add optional slug column to profile model (Auth v3 step 1)

### DIFF
--- a/apps/platform-app/prisma/migrations/20241203132444_add_optional_slug_column_to_profile_table/migration.sql
+++ b/apps/platform-app/prisma/migrations/20241203132444_add_optional_slug_column_to_profile_table/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[slug]` on the table `Profile` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Profile" ADD COLUMN     "slug" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_slug_key" ON "Profile"("slug");

--- a/apps/platform-app/prisma/schema.prisma
+++ b/apps/platform-app/prisma/schema.prisma
@@ -13,17 +13,17 @@ datasource db {
 }
 
 model User {
-  id             String         @id @default(uuid())
-  email          String         @unique
-  emailVerified  DateTime?
-  avatarUrl      String?
-  accounts       Account[]
-  profile        Profile?
-  githubDetails  GitHubDetails?
-  roles          Role[]         @default([USER])
-  nerdbordUserId String?        @unique
-  createdAt      DateTime       @default(now())
-  viewedProfiles ProfileView[]
+  id              String           @id @default(uuid())
+  email           String           @unique
+  emailVerified   DateTime?
+  avatarUrl       String?
+  accounts        Account[]
+  profile         Profile?
+  githubDetails   GitHubDetails?
+  roles           Role[]           @default([USER])
+  nerdbordUserId  String?          @unique
+  createdAt       DateTime         @default(now())
+  viewedProfiles  ProfileView[]
   contactRequests ContactRequest[]
 }
 
@@ -56,6 +56,7 @@ model VerificationToken {
 
 model Profile {
   id                       String            @id @default(uuid())
+  slug                     String?           @unique
   user                     User              @relation(fields: [userId], references: [id])
   userId                   String            @unique
   fullName                 String
@@ -83,7 +84,7 @@ model Profile {
   createdAt                DateTime          @default(now())
   updatedAt                DateTime?         @updatedAt
   profileViews             ProfileView[]
-  language                 Language[]        
+  language                 Language[]
 }
 
 model Technology {
@@ -126,33 +127,33 @@ model ContactRequest {
   senderFullName String
   senderEmail    String
   senderId       String?
-  sender         User?     @relation(fields: [senderId], references: [id])
+  sender         User?    @relation(fields: [senderId], references: [id])
   profile        Profile  @relation(fields: [profileId], references: [id])
   profileId      String
   createdAt      DateTime @default(now())
 }
 
 model ProfileView {
-  id                 String   @id @default(uuid())
-  viewerId           String
-  viewedProfileId    String
-  createdAt          DateTime @default(now())
-  viewer             User     @relation(fields: [viewerId], references: [id])
-  viewedProfile      Profile  @relation(fields: [viewedProfileId], references: [id])
+  id              String   @id @default(uuid())
+  viewerId        String
+  viewedProfileId String
+  createdAt       DateTime @default(now())
+  viewer          User     @relation(fields: [viewerId], references: [id])
+  viewedProfile   Profile  @relation(fields: [viewedProfileId], references: [id])
 }
 
 model Language {
-  id                 String     @id @default(uuid())
-  name               String     @unique
-  profiles           Profile[]  
+  id       String    @id @default(uuid())
+  name     String    @unique
+  profiles Profile[]
 }
 
 enum Currency {
-   PLN
-   EUR
-   USD
- }
- 
+  PLN
+  EUR
+  USD
+}
+
 enum EmploymentType {
   FULL_TIME
   PART_TIME

--- a/apps/platform-app/src/app/[locale]/(profile)/_models/profile.model.ts
+++ b/apps/platform-app/src/app/[locale]/(profile)/_models/profile.model.ts
@@ -28,6 +28,7 @@ export function createProfileModel(data: ProfileWithRelations): ProfileModel {
   return {
     id: data.id,
     userId: data.userId,
+    slug: data.slug,
     fullName: data.fullName,
     linkedIn: data.linkedIn,
     bio: data.bio,


### PR DESCRIPTION
## Summary
This change is a preparatory step for merging the Auth v3 PR (#366) and should be merged first to ensure a smooth transition.

## Details
#### New Column Introduction:
Adds a slug column to the Profile model, initially set as optional. This allows time to generate slugs for existing users without disrupting the current workflow.

#### Slug Population Plan:
After deploying this PR to production:

1. Run a query to populate all slugs using GitHub usernames from the githubDetails model.
2. Merge PR #366, which makes the slug field required.

**Important**: These steps (this PR, the query, and #366) should be executed sequentially, with minimal time between each, to prevent profiles from being created without slugs during the transition.

## Testing
This change has been tested and ensures that:

- Existing user profiles load and can be edited as expected.
- New users can create, edit, and interact with profiles seamlessly.
- Existing users can log in, log out, and create profiles as before.
- New signups and logins function correctly.

**Note**: This update does not impact the current application flow.