### PR TITLE
fix: redirect users to signin page in createProfile btn

### DIFF
--- a/apps/platform-app/src/app/[locale]/(profile)/(routes)/my-profile/(components)/CreateProfileBtn/CreateProfileBtn.tsx
+++ b/apps/platform-app/src/app/[locale]/(profile)/(routes)/my-profile/(components)/CreateProfileBtn/CreateProfileBtn.tsx
@@ -3,8 +3,7 @@ import { I18nNamespaces } from '@/i18n/request'
 import { AppRoutes } from '@/utils/routes'
 import { Button } from '@gdh/ui-system'
 import { AddIcon } from '@gdh/ui-system/icons'
-import { Role } from '@prisma/client'
-import { signIn, useSession } from 'next-auth/react'
+import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { usePathname, useRouter } from 'next/navigation'
 import { useState } from 'react'
@@ -24,9 +23,7 @@ const CreateProfileBtn = () => {
   const onClickHandler = async () => {
     setIsCalled(true)
     if (!session) {
-      await signIn('github', {
-        callbackUrl: `${AppRoutes.oAuth}?role=${Role.SPECIALIST}`,
-      })
+      router.push(AppRoutes.signIn)
       return
     }
     router.push(AppRoutes.createProfile)


### PR DESCRIPTION
create profile btn was hardcoded to use github auth. Now it redirects to /signin if there is no user logged in and if there is a user without profile it redirects to /my-profile/create